### PR TITLE
Update typings to prevent TS error when using StateObservable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,7 +37,7 @@ export declare interface Epic<Input extends Action = any, Output extends Input =
   (action$: ActionsObservable<Input>, state$: StateObservable<State>, dependencies: Dependencies): Observable<Output>;
 }
 
-export interface EpicMiddleware<T extends Action, O extends T = T, S = void, D = any> extends Middleware {
+export interface EpicMiddleware<T extends Action, O extends T = T, S = any, D = any> extends Middleware {
   run(rootEpic: Epic<T, O, S, D>): void;
 }
 
@@ -45,9 +45,9 @@ interface Options<D = any> {
   dependencies?: D;
 }
 
-export declare function createEpicMiddleware<T extends Action, O extends T = T, S = void, D = any>(options?: Options<D>): EpicMiddleware<T, O, S, D>;
+export declare function createEpicMiddleware<T extends Action, O extends T = T, S = any, D = any>(options?: Options<D>): EpicMiddleware<T, O, S, D>;
 
-export declare function combineEpics<T extends Action, O extends T = T, S = void, D = any>(...epics: Epic<T, O, S, D>[]): Epic<T, O, S, D>;
+export declare function combineEpics<T extends Action, O extends T = T, S = any, D = any>(...epics: Epic<T, O, S, D>[]): Epic<T, O, S, D>;
 export declare function combineEpics<E>(...epics: E[]): E;
 export declare function combineEpics(...epics: any[]): any;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,11 +33,13 @@ export declare class StateObservable<S> extends Observable<S> {
   value: S
 }
 
-export declare interface Epic<Input extends Action = any, Output extends Input = Input, State = any, Dependencies = any> {
+type State = any;
+
+export declare interface Epic<Input extends Action = any, Output extends Input = Input, State = State, Dependencies = any> {
   (action$: ActionsObservable<Input>, state$: StateObservable<State>, dependencies: Dependencies): Observable<Output>;
 }
 
-export interface EpicMiddleware<T extends Action, O extends T = T, S = any, D = any> extends Middleware {
+export interface EpicMiddleware<T extends Action, O extends T = T, S = State, D = any> extends Middleware {
   run(rootEpic: Epic<T, O, S, D>): void;
 }
 
@@ -45,9 +47,9 @@ interface Options<D = any> {
   dependencies?: D;
 }
 
-export declare function createEpicMiddleware<T extends Action, O extends T = T, S = any, D = any>(options?: Options<D>): EpicMiddleware<T, O, S, D>;
+export declare function createEpicMiddleware<T extends Action, O extends T = T, S = State, D = any>(options?: Options<D>): EpicMiddleware<T, O, S, D>;
 
-export declare function combineEpics<T extends Action, O extends T = T, S = any, D = any>(...epics: Epic<T, O, S, D>[]): Epic<T, O, S, D>;
+export declare function combineEpics<T extends Action, O extends T = T, S = State, D = any>(...epics: Epic<T, O, S, D>[]): Epic<T, O, S, D>;
 export declare function combineEpics<E>(...epics: E[]): E;
 export declare function combineEpics(...epics: any[]): any;
 


### PR DESCRIPTION
<!-- If this is your first PR for redux-observable, please mark these boxes to confirm (otherwise you can exclude them)-->

- [x] I have read the [Contributor Guide](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md)
- [x] My commit messages are in [conventional-changelog-standard](https://github.com/redux-observable/redux-observable/blob/master/CONTRIBUTING.md#sending-a-pull-request) format.

Updates typings to prevent the error when using an Epic with the `StateObservable`